### PR TITLE
"fixes to work with current and future glmnet"

### DIFF
--- a/R/my.cv.glmnet.R
+++ b/R/my.cv.glmnet.R
@@ -1,103 +1,126 @@
-my.cv.glmnet <-
-function (x, y, weights, offset = NULL, lambda = NULL, type.measure = c("mse", 
-                                                           "deviance", "class", "auc", "mae"), nfolds = 10, foldid,
-                                                           lambda.choice = c("lambda.1se", "lambda.min"),
-            grouped = TRUE, keep = FALSE, parallel = FALSE, ...) 
-{
+my.cv.glmnet = function(x, y, weights, offset = NULL, lambda = NULL, type.measure = c(
+                          "mse",
+                          "deviance", "class", "auc", "mae"
+                        ), nfolds = 10, foldid,
+                        lambda.choice = c("lambda.1se", "lambda.min"),
+                        grouped = TRUE, keep = FALSE, parallel = FALSE, ...) {
   lambda.choice = match.arg(lambda.choice)
-
-  if (missing(type.measure)) 
+  if (missing(type.measure))
     type.measure = "default"
   else type.measure = match.arg(type.measure)
-  if (!is.null(lambda) && length(lambda) < 2) 
+  if (!is.null(lambda) && length(lambda) < 2)
     stop("Need more than one value of lambda for cv.glmnet")
   N = nrow(x)
-  if (missing(weights)) 
+  if (missing(weights))
     weights = rep(1, N)
   else weights = as.double(weights)
   y = drop(y)
   glmnet.call = match.call(expand.dots = TRUE)
-  which = match(c("type.measure", "nfolds", "foldid", "grouped", 
-    "keep"), names(glmnet.call), F)
-  if (any(which)) 
+  which = match(c(
+    "type.measure", "nfolds", "foldid", "grouped",
+    "keep"
+  ), names(glmnet.call), F)
+  if (any(which))
     glmnet.call = glmnet.call[-which]
   glmnet.call[[1]] = as.name("glmnet")
-  glmnet.object = glmnet(x, y, weights = weights, offset = offset, 
-    lambda = lambda, ...)
+  glmnet.object = glmnet(x, y,
+    weights = weights, offset = offset,
+    lambda = lambda, ...
+  )
   glmnet.object$call = glmnet.call
   is.offset = glmnet.object$offset
-###Next line is commented out so each call generates its own lambda sequence
-# lambda=glmnet.object$lambda
- if (inherits(glmnet.object, "multnet") && !glmnet.object$grouped) {
+  ### Next line is commented out so each call generates its own lambda sequence
+  # lambda=glmnet.object$lambda
+  if (inherits(glmnet.object, "multnet") && !glmnet.object$grouped) {
     nz = predict(glmnet.object, type = "nonzero")
     nz = sapply(nz, function(x) sapply(x, length))
     nz = ceiling(apply(nz, 1, median))
-  }
-  else nz = sapply(predict(glmnet.object, type = "nonzero"), 
-         length)
-  if (missing(foldid)) 
+  } else nz = sapply(
+    predict(glmnet.object, type = "nonzero"),
+    length
+  )
+  if (missing(foldid))
     foldid = sample(rep(seq(nfolds), length = N))
   else nfolds = max(foldid)
-  if (nfolds < 3) 
+  if (nfolds < 3)
     stop("nfolds must be bigger than 3; nfolds=10 recommended")
   outlist = as.list(seq(nfolds))
   if (parallel) {
-#  if (parallel && require(foreach)) {
-    outlist = foreach(i = seq(nfolds), .packages = c("glmnet")) %dopar% 
-    {
+    #  if (parallel && require(foreach)) {
+    outlist = foreach(i = seq(nfolds), .packages = c("glmnet")) %dopar% {
       which = foldid == i
-      if (is.matrix(y)) 
+      if (is.matrix(y))
         y_sub = y[!which, ]
       else y_sub = y[!which]
-      if (is.offset) 
+      if (is.offset)
         offset_sub = as.matrix(offset)[!which, ]
       else offset_sub = NULL
-      glmnet(x[!which, , drop = FALSE], y_sub, lambda = lambda, 
-             offset = offset_sub, weights = weights[!which], 
-             ...)
+      glmnet(x[!which, , drop = FALSE], y_sub,
+        lambda = lambda,
+        offset = offset_sub, weights = weights[!which],
+        ...
+      )
     }
-  }
-  else {
+  } else {
     for (i in seq(nfolds)) {
       which = foldid == i
-      if (is.matrix(y)) 
+      if (is.matrix(y))
         y_sub = y[!which, ]
       else y_sub = y[!which]
-      if (is.offset) 
+      if (is.offset)
         offset_sub = as.matrix(offset)[!which, ]
       else offset_sub = NULL
-      outlist[[i]] = glmnet(x[!which, , drop = FALSE], 
-               y_sub, lambda = lambda, offset = offset_sub, 
-               weights = weights[!which], ...)
+      outlist[[i]] = glmnet(x[!which, , drop = FALSE],
+        y_sub,
+        lambda = lambda, offset = offset_sub,
+        weights = weights[!which], ...
+      )
     }
   }
-  fun = paste("cv", class(glmnet.object)[[1]], sep = ".")
+  # cv.elnet no longer exists
+  fun = paste("cv", class(glmnet.object)[[2]], sep = ".")
   lambda = glmnet.object$lambda
-  cvstuff = do.call(fun, list(outlist, lambda, x, y, weights, 
-    offset, foldid, type.measure, grouped, keep))
+  # named arguments to cv.glmnet - 'alignment' used to throw error
+  cvstuff = do.call(fun, list(
+    outlist,
+    lambda = lambda, x = x, y = y, weights = weights,
+    offset = offset, foldid = foldid, type.measure = type.measure, grouped = grouped, keep = keep
+  ))
   cvm = cvstuff$cvm
   cvsd = cvstuff$cvsd
-  nas=is.na(cvsd)
-  if(any(nas)){
-    lambda=lambda[!nas]
-    cvm=cvm[!nas]
-    cvsd=cvsd[!nas]
-    nz=nz[!nas]
+  nas = is.na(cvsd)
+  if (any(nas)) {
+    lambda = lambda[!nas]
+    cvm = cvm[!nas]
+    cvsd = cvsd[!nas]
+    nz = nz[!nas]
   }
   cvname = cvstuff$name
-  out = list(lambda = lambda, cvm = cvm, cvsd = cvsd, cvup = cvm + 
+  out = list(lambda = lambda, cvm = cvm, cvsd = cvsd, cvup = cvm +
     cvsd, cvlo = cvm - cvsd, nzero = nz, name = cvname, glmnet.fit = glmnet.object)
-  if (keep) 
+  if (keep)
     out = c(out, list(fit.preval = cvstuff$fit.preval, foldid = foldid))
-  lamin=if(cvname=="AUC")getmin(lambda,-cvm,cvsd)
+  lamin = if (cvname == "AUC") getmin(lambda, -cvm, cvsd)
   else getmin(lambda, cvm, cvsd)
   obj = c(out, as.list(lamin))
   class(obj) = "cv.glmnet"
-  
+
   lambda.opt = as.numeric(obj[lambda.choice])
   cv.betas.list = lapply(outlist, function(elem) coef(elem, s = lambda.opt))
-  cv.betas = Reduce(rbind, lapply(cv.betas.list, FUN=as.numeric))
+  cv.betas = Reduce(rbind, lapply(cv.betas.list, FUN = as.numeric))
   obj[[length(obj) + 1]] = cv.betas
   names(obj)[length(obj)] = "cv.betas"
   obj
+}
+
+# internal function from glmnet that is no longer exported
+getmin = function(lambda, cvm, cvsd) {
+  cvmin = min(cvm, na.rm = TRUE)
+  idmin = cvm <= cvmin
+  lambda.min = max(lambda[idmin], na.rm = TRUE)
+  idmin = match(lambda.min, lambda)
+  semin = (cvm + cvsd)[idmin]
+  idmin = cvm <= semin
+  lambda.1se = max(lambda[idmin], na.rm = TRUE)
+  list(lambda.min = lambda.min, lambda.1se = lambda.1se)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,16 +11,22 @@ knitr::opts_chunk$set(
   fig.path = "README-"
 )
 ```
-A cross estimation procedure is used to estimate average treatment effects and confidence intervals for randomized experiments.  The data is split into $K$ folds, the estimates in each fold are averaged to give $\hat{\tau}$, and an estimate of the variance of $\hat{\tau}$ is computed.  For each fold $k$ and treatments $w = 0, 1$, suppose that $\bar{Y}_w^{(k)}, \bar{X}_w^{(k)}$ are the means in that fold.  Also, suppose that $\hat{\beta}_w^{(-k)}$ are regression adjustments calculated on the other folds based on demeaned data.  Then, the average treatment effect estimate is computed with the formula 
+A cross estimation procedure is used to estimate average treatment effects and confidence intervals for randomized experiments.  The data is split into $K$ folds, the estimates in each fold are averaged to give $\hat{\tau}$, and an estimate of the variance of $\hat{\tau}$ is computed.  For each fold $k$ and treatments $w = 0, 1$, suppose that $\bar{Y}_w^{(k)}, \bar{X}_w^{(k)}$ are the means in that fold.  Also, suppose that $\hat{\beta}_w^{(-k)}$ are regression adjustments calculated on the other folds based on demeaned data.  Then, the average treatment effect estimate is computed with the formula
+
 \[ \hat{\tau}^{(k)} = \bar{Y}_1^{(k)} - \bar{X}_1^{(k)}\hat{\beta}^{(1,-k)} + \bar{X}^{(k)}\hat{\beta}^{(1,-k)} - (\bar{Y}_0^{(k)} - \bar{X}_0^{(k)}\hat{\beta}^{(0,-k)} + \bar{X}^{(k)}\hat{\beta}^{(0,-k)}) \]
+
 \[ \hat{\tau} = \sum_{k=1}^K\hat{\tau}^{(k)}n^{(k)}/n \]
 
 The variance of this estimate is computed with the formula
+
 \[ \text{Var}(\hat{\tau}^{(k)}) = \sum_{w = 0,1}\text{Var}(Y_w^{(k)}) / n_w^{(k)} - 2\text{Cov}(Y_w^{(k)}, X_w^{(k)}\bar{\hat{\beta}}^{(-k)}) / n_w^{(k)} + \text{Var}(X_w^{(k)}\bar{\hat{\beta}}^{(-k)}) / n_w^{(k)} \]
+
 \[ \text{Var}(\hat{\tau})=\sum_{k=1}^K\text{Var}(\hat{\tau}^{(k)})(n^{(k)}/n)^2 \]
+
 The covariances and variances above are substituted with estimated values in the data to obtain an estimate of the variance of $\hat{\tau}$.  Confidence intervals are also provided under a Gaussian assumption, which holds asymptotically under certain conditions.
 
 The glmnet package is used for the estimation of regression adjustments.  The regularization parameter is chosen by cross validation, which can be done on the same $k$ folds as used for cross estimation above.  A simulated example is below:
+
 ```{r}
 # simulation with Gaussian covariates based on Figure 1 in reference paper
 library(crossEstimation)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-A cross estimation procedure is used to estimate average treatment effects and confidence intervals for randomized experiments. The data is split into *K* folds, the estimates in each fold are averaged to give $\\hat{\\tau}$, and an estimate of the variance of $\\hat{\\tau}$ is computed. For each fold *k* and treatments *w* = 0, 1, suppose that $\\bar{Y}\_w^{(k)}, \\bar{X}\_w^{(k)}$ are the means in that fold. Also, suppose that $\\hat{\\beta}\_w^{(-k)}$ are regression adjustments calculated on the other folds based on demeaned data. Then, the average treatment effect estimate is computed with the formula
-$$ \\hat{\\tau}^{(k)} = \\bar{Y}\_1^{(k)} - \\bar{X}\_1^{(k)}\\hat{\\beta}^{(1,-k)} + \\bar{X}^{(k)}\\hat{\\beta}^{(1,-k)} - (\\bar{Y}\_0^{(k)} - \\bar{X}\_0^{(k)}\\hat{\\beta}^{(0,-k)} + \\bar{X}^{(k)}\\hat{\\beta}^{(0,-k)}) $$
-$$ \\hat{\\tau} = \\sum\_{k=1}^K\\hat{\\tau}^{(k)}n^{(k)}/n $$
- The variance of this estimate is computed with the formula
-$$ \\text{Var}(\\hat{\\tau}^{(k)}) = \\sum\_{w = 0,1}\\text{Var}(Y\_w^{(k)}) / n\_w^{(k)} - 2\\text{Cov}(Y\_w^{(k)}, X\_w^{(k)}\\bar{\\hat{\\beta}}^{(-k)}) / n\_w^{(k)} + \\text{Var}(X\_w^{(k)}\\bar{\\hat{\\beta}}^{(-k)}) / n\_w^{(k)} $$
-$$ \\text{Var}(\\hat{\\tau})=\\sum\_{k=1}^K\\text{Var}(\\hat{\\tau}^{(k)})(n^{(k)}/n)^2 $$
- The covariances and variances above are substituded with estimated values in the data to obtain an estimate of the variance of $\\hat{\\tau}$. Confidence intervals are also provided under a Gaussian assumption, which holds asymptotically under certain conditions. The glmnet package is used for the estimation of regression adjustments. The regularization parameter is chosen by cross validation, which can be done on the same *k* folds as used for cross estimation above. A simulated example is below:
+
+A cross estimation procedure is used to estimate average treatment
+effects and confidence intervals for randomized experiments. The data is
+split into $K$ folds, the estimates in each fold are averaged to give
+$\hat{\tau}$, and an estimate of the variance of $\hat{\tau}$ is
+computed. For each fold $k$ and treatments $w = 0, 1$, suppose that
+$\bar{Y}_w^{(k)}, \bar{X}_w^{(k)}$ are the means in that fold. Also,
+suppose that $\hat{\beta}_w^{(-k)}$ are regression adjustments
+calculated on the other folds based on demeaned data. Then, the average
+treatment effect estimate is computed with the formula
+
+$$ \hat{\tau}^{(k)} = \bar{Y}_1^{(k)} - \bar{X}_1^{(k)}\hat{\beta}^{(1,-k)} + \bar{X}^{(k)}\hat{\beta}^{(1,-k)} - (\bar{Y}_0^{(k)} - \bar{X}_0^{(k)}\hat{\beta}^{(0,-k)} + \bar{X}^{(k)}\hat{\beta}^{(0,-k)}) $$
+
+$$ \hat{\tau} = \sum_{k=1}^K\hat{\tau}^{(k)}n^{(k)}/n $$
+
+The variance of this estimate is computed with the formula
+
+$$ \text{Var}(\hat{\tau}^{(k)}) = \sum_{w = 0,1}\text{Var}(Y_w^{(k)}) / n_w^{(k)} - 2\text{Cov}(Y_w^{(k)}, X_w^{(k)}\bar{\hat{\beta}}^{(-k)}) / n_w^{(k)} + \text{Var}(X_w^{(k)}\bar{\hat{\beta}}^{(-k)}) / n_w^{(k)} $$
+
+$$ \text{Var}(\hat{\tau})=\sum_{k=1}^K\text{Var}(\hat{\tau}^{(k)})(n^{(k)}/n)^2 $$
+
+The covariances and variances above are substituted with estimated
+values in the data to obtain an estimate of the variance of
+$\hat{\tau}$. Confidence intervals are also provided under a Gaussian
+assumption, which holds asymptotically under certain conditions.
+
+The glmnet package is used for the estimation of regression adjustments.
+The regularization parameter is chosen by cross validation, which can be
+done on the same $k$ folds as used for cross estimation above. A
+simulated example is below:
 
 ``` r
 # simulation with Gaussian covariates based on Figure 1 in reference paper
@@ -38,5 +61,5 @@ for (i in 1:100) {
   cover <- cover + (res$conf.int[1] < tau & tau < res$conf.int[2])
 }
 cover
-#> [1] 92
+#> [1] 90
 ```


### PR DESCRIPTION
Minor updates to make this work with current versions of glmnet. `cv.elnet` no longer exists, so the function call uses `cv.glmnet` instead. Arguments for `cvstuff` are now named because changes to argument order across versions of glmnet broke `my.cv.glmnet`. 
Finally, Readme renders math correctly. 